### PR TITLE
Typo in parameter validation

### DIFF
--- a/lib/utils/ConverterFactory.js
+++ b/lib/utils/ConverterFactory.js
@@ -34,7 +34,7 @@ class ConverterFactory {
      */
     static createSinkSchemaConverter(tableSchema, etlFunction, schemaAttributes = {}) {
 
-        if (typeof sequelizeSchema !== "object") {
+        if (typeof tableSchema !== "object") {
             throw new Error("sequelizeSchema must be an object.");
         }
 


### PR DESCRIPTION
createSinkSchemaConverter always failed, because it checked a non existing variable for type object